### PR TITLE
Add support for custom components in markdown

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -24,6 +24,7 @@ module.exports = {
     `gatsby-plugin-sharp`,
     `gatsby-transformer-remark`,
     `gatsby-transformer-sharp`,
+    `gatsby-remark-component`,
     {
       resolve: `gatsby-plugin-manifest`,
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "learnxasy",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1340,6 +1340,14 @@
       "integrity": "sha512-EFQurCyEnZLSM2Q1BYDTUmsOJPSOYEQd18Fvq8bGo8hnBHoGLWLWWyNi2l4cYhtpKmIXyhvQqa6/WaEpKPzvqA==",
       "requires": {
         "core-js": "^2.5.7"
+      }
+    },
+    "@mapbox/hast-util-table-cell-style": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz",
+      "integrity": "sha512-QsEsh5YaDvHoMQ2YHdvZy2iDnU3GgKVBTcHf6cILyoWDZtPSdlG444pL/ioPYO/GpXSfODBb9sefEetfC4v9oA==",
+      "requires": {
+        "unist-util-visit": "^1.3.0"
       }
     },
     "@mikaelkristiansson/domready": {
@@ -7194,6 +7202,14 @@
         "warning": "^3.0.0"
       }
     },
+    "gatsby-remark-component": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-component/-/gatsby-remark-component-1.1.3.tgz",
+      "integrity": "sha512-bRJ2r7FgdH12+ahsKSFe+OWPTmjw8lBD+S0ytm+p1M9Bfmq2Qai+ROacNAp7d18vZLEhRpzznWJgSU7gEejVXg==",
+      "requires": {
+        "unist-util-visit": "^1.1.1"
+      }
+    },
     "gatsby-source-filesystem": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.0.tgz",
@@ -12633,6 +12649,16 @@
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
+      }
+    },
+    "rehype-react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-3.1.0.tgz",
+      "integrity": "sha512-7SiLiqNudSGkvhrePkdKqdUvngZqzG+PJhdR5EeIFELz2j2ek4aO5DHbxUXYvaZfqUiBDO2Aeq1OROUmxmu+Vg==",
+      "requires": {
+        "@mapbox/hast-util-table-cell-style": "^0.1.3",
+        "has": "^1.0.1",
+        "hast-to-hyperscript": "^5.0.0"
       }
     },
     "relay-runtime": {

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
     "gatsby-plugin-offline": "^2.2.0",
     "gatsby-plugin-react-helmet": "^3.1.0",
     "gatsby-plugin-sharp": "^2.2.1",
+    "gatsby-remark-component": "^1.1.3",
     "gatsby-source-filesystem": "^2.1.0",
     "gatsby-transformer-remark": "^2.5.0",
     "gatsby-transformer-sharp": "^2.2.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-helmet": "^5.2.1"
+    "react-helmet": "^5.2.1",
+    "rehype-react": "^3.1.0"
   },
   "devDependencies": {
     "gh-pages": "^2.0.1",

--- a/src/components/embeds/kotlinplay.js
+++ b/src/components/embeds/kotlinplay.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+const KotlinPlayground = ({ src, height }) => (
+  <iframe 
+    title={`Kotlin Playground (${src})`}
+    height={ height || 180} 
+    width="100%" 
+    src={ src.startsWith("http") ? src : `https://pl.kotl.in/${src}?theme=darcula`} 
+    scrolling="no" 
+    frameborder="no" 
+    allowtransparency="true"
+  >
+  </iframe>
+);
+
+export default KotlinPlayground;

--- a/src/components/renderAst.js
+++ b/src/components/renderAst.js
@@ -1,0 +1,13 @@
+import React from "react";
+import RehypeReact from "rehype-react";
+
+import KotlinPlayground from "./embeds/kotlinplay";
+
+const renderAst = new RehypeReact({
+  createElement: React.createElement,
+  components: {
+    "kotlin-playground": KotlinPlayground
+  }
+}).Compiler;
+
+export default renderAst;

--- a/src/templates/lesson.js
+++ b/src/templates/lesson.js
@@ -1,7 +1,9 @@
 import React from "react";
 import { graphql, Link } from "gatsby";
 import { css } from "@emotion/core";
+
 import Layout from "../components/layout";
+import renderAst from "../components/renderAst";
 
 export default ({ data: { markdownRemark: context } }) => (
   <Layout x={context.fields.learn} y={context.fields.as}>
@@ -12,9 +14,7 @@ export default ({ data: { markdownRemark: context } }) => (
       `}
     >
       <h1>Lesson {context.frontmatter.lessonNumber}: {context.frontmatter.title}</h1>
-      <div 
-        dangerouslySetInnerHTML={{ __html: context.html }} 
-      />
+      <div>{renderAst(context.htmlAst)}</div>
     </div>
   </Layout>
 );
@@ -22,7 +22,7 @@ export default ({ data: { markdownRemark: context } }) => (
 export const query = graphql`
   query($learn: String!, $as: String!, $lesson: String!) {
     markdownRemark(fields: { learn: { eq: $learn }, as: { eq: $as }, lesson: { eq: $lesson } }) {      
-      html
+      htmlAst
       frontmatter {
         title
         lessonNumber


### PR DESCRIPTION
Add support for rendering custom react components in markdown, and add a `KotlinPlayground` element.